### PR TITLE
Final update for 2.35

### DIFF
--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -80,25 +80,25 @@ Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }
 {\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname 
 ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid205773\rsid219208\rsid225408
-\rsid265763\rsid346080\rsid595465\rsid601046\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1575696\rsid1654655\rsid1857973\rsid2054605\rsid2243781\rsid2517006\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3097678\rsid3300860\rsid3430394
-\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid4522193\rsid4740061\rsid4745200\rsid4925283\rsid4983150\rsid4993354\rsid5113752\rsid5209339\rsid5267713\rsid5703879\rsid5847035\rsid6053627\rsid6054960
-\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7432229\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782\rsid8596828\rsid8662784\rsid8790405\rsid8876191\rsid9047498\rsid9112866\rsid9338186
-\rsid9376723\rsid9520485\rsid9639341\rsid9708402\rsid9765064\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10580546\rsid10900280\rsid10963467\rsid11041950\rsid11227030\rsid11488686\rsid11605034\rsid11823514\rsid11884716\rsid12258164\rsid12271374
-\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708\rsid13401205\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14097372\rsid14169246\rsid14577313\rsid14684132\rsid14697282
-\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid15428007\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid15873118\rsid15948729\rsid16203271\rsid16207041\rsid16258407\rsid16271519\rsid16272684\rsid16326917
-\rsid16473260\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
-{\revtim\yr2020\mo5\dy8\hr14\min8}{\version92}{\edmins11868}{\nofpages31}{\nofwords9548}{\nofchars54429}{\nofcharsws63850}{\vern127}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid265763\rsid346080\rsid595465\rsid601046\rsid677819\rsid742267\rsid928241\rsid1260987\rsid1575696\rsid1654655\rsid1857973\rsid2054605\rsid2243781\rsid2517006\rsid2579094\rsid2584542\rsid2653562\rsid2902416\rsid2978753\rsid3097678\rsid3300860
+\rsid3430394\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4149699\rsid4213396\rsid4222850\rsid4357927\rsid4522193\rsid4740061\rsid4745200\rsid4925283\rsid4983150\rsid4993354\rsid5113752\rsid5207971\rsid5209339\rsid5267713\rsid5703879\rsid5847035
+\rsid6053627\rsid6054960\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7432229\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8350100\rsid8394203\rsid8410782\rsid8596828\rsid8662784\rsid8790405\rsid8876191\rsid9047498
+\rsid9112866\rsid9338186\rsid9376723\rsid9520485\rsid9639341\rsid9708402\rsid9765064\rsid9974690\rsid9986361\rsid10315109\rsid10488541\rsid10580546\rsid10900280\rsid10963467\rsid11041950\rsid11227030\rsid11488686\rsid11605034\rsid11823514\rsid11884716
+\rsid12258164\rsid12271374\rsid12272355\rsid12353294\rsid12523992\rsid12541957\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12978708\rsid13401205\rsid13437246\rsid13662136\rsid13853169\rsid13987238\rsid14097372\rsid14169246\rsid14577313
+\rsid14684132\rsid14697282\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid15428007\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid15873118\rsid15948729\rsid16203271\rsid16207041\rsid16258407\rsid16271519
+\rsid16272684\rsid16326917\rsid16473260\rsid16517051\rsid16527420\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo7\dy1\hr7\min41}{\version93}{\edmins11869}{\nofpages31}{\nofwords9548}{\nofchars54430}{\nofcharsws63851}{\vern5}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBYamtQBXssmYLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16258407 \chftnsep 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5207971 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16258407 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5207971 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16258407 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5207971 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16258407 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5207971 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s24\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid16203271 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 
@@ -211,9 +211,9 @@ Citrix Group Policy PowerShell module.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 \hich\af37\dbch\af31505\loch\f37  HY\hich\af37\dbch\af31505\loch\f37 PERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16271519 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d000000009f0091330000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634\hich\af37\dbch\af31505\loch\f37 b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000c100c0700000000000044f70000000006f000000000000003600333100006f00f97f000000763d000000009f009133000002}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid16271519\charrsid16271519 \hich\af37\dbch\af31505\loch\f37 https://carlwebster.sharefile.com/d-s52634\hich\af37\dbch\af31505\loch\f37 b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 Save the file to your default download folder.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 
@@ -252,7 +252,7 @@ If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \lt
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX130147" }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e0000000000000000000000003100110700ff008100004f00000000002d00054554eb770072}}}{\fldrslt {\rtlch\fcs1 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000022003000000000000000640000000000000049000000000000000000002c004800390100087e0000000000000000000000003100110700ff008100004f00000000002d00054554eb77007200}}}{\fldrslt {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \hich\af37\dbch\af31505\loch\f37 . The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
  the updated version is from Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 
@@ -425,12 +425,12 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the \hich\f2 \endash \loch\f2 AdminAddress (AA) parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This script supports versions of XenApp/XenDesktop starting with 7.8.
+\par \hich\af2\dbch\af31505\loch\f2     This s\hich\af2\dbch\af31505\loch\f2 cript supports versions of XenApp/XenDesktop starting with 7.8.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     NOTE: The account used to run this script must have at least Read access to the SQL
 \par \hich\af2\dbch\af31505\loch\f2     Server(s) that hold(s) the Citrix Site, Monitoring, and Logging databases.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     By defaul\hich\af2\dbch\af31505\loch\f2 t, only gives summary information for:
+\par \hich\af2\dbch\af31505\loch\f2     By default, only gi\hich\af2\dbch\af31505\loch\f2 ves summary information for:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         App-V Publishing
 \par \hich\af2\dbch\af31505\loch\f2         AppDisks
@@ -441,7 +441,7 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
 \par \hich\af2\dbch\af31505\loch\f2         Logging
-\par \hich\af2\dbch\af31505\loch\f2         Machi\hich\af2\dbch\af31505\loch\f2 ne Catalogs
+\par \hich\af2\dbch\af31505\loch\f2         Machine Catalog\hich\af2\dbch\af31505\loch\f2 s
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2         Zones
@@ -461,16 +461,16 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     Using the D\hich\af2\dbch\af31505\loch\f2 eliveryGroups parameter can cause the report to take a very long time to
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
-\par \hich\af2\dbch\af31505\loch\f2     take an extremel\hich\af2\dbch\af31505\loch\f2 y long time to complete and generate an exceptionally long report.
+\par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to co\hich\af2\dbch\af31505\loch\f2 mplete and generate an exceptionally long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.8+ Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following lang\hich\af2\dbch\af31505\loch\f2 uage versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of \hich\af2\dbch\af31505\loch\f2 Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
@@ -682,14 +682,14 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
@@ -697,48 +697,48 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
-\par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Alph\hich\af2\dbch\af31505\loch\f2 abet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 works in 2010 but Subtitle/Subject & Author fields need to be moved
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Sub\hich\af2\dbch\af31505\loch\f2 title/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Cubicles (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Cubicles \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works\hich\af2\dbch\af31505\loch\f2  in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fi\hich\af2\dbch\af31505\loch\f2 t; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manuall\hich\af2\dbch\af31505\loch\f2 y changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't f\hich\af2\dbch\af31505\loch\f2 it; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 resized or font cha\hich\af2\dbch\af31505\loch\f2 nged to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 20\hich\af2\dbch\af31505\loch\f2 16, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) \hich\af2\dbch\af31505\loch\f2 (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless \hich\af2\dbch\af31505\loch\f2 changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works\hich\af2\dbch\af31505\loch\f2 )
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parame\hich\af2\dbch\af31505\loch\f2 ters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -748,12 +748,12 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Controllers [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         As of version 2.22, adds the following information to the Controllers section:
-\par \hich\af2\dbch\af31505\loch\f2                 List of installed Microsoft H\hich\af2\dbch\af31505\loch\f2 otfixes and Updates
-\par \hich\af2\dbch\af31505\loch\f2                 List of Citrix installed components
+\par \hich\af2\dbch\af31505\loch\f2                 List of installed Microsoft Hotfixes and Updates
+\par \hich\af2\dbch\af31505\loch\f2                 List of\hich\af2\dbch\af31505\loch\f2  Citrix installed components
 \par \hich\af2\dbch\af31505\loch\f2                 List of Windows installed Roles and Features
 \par \hich\af2\dbch\af31505\loch\f2                 Appendix C List of installed Microsoft Hotfixes and Updates for all
 \par \hich\af2\dbch\af31505\loch\f2                 Controllers
-\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Appendix D List of Citrix installed components for all Controllers
+\par \hich\af2\dbch\af31505\loch\f2                 Appendix D List of Citrix installed co\hich\af2\dbch\af31505\loch\f2 mponents for all Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Appendix E List of Windows installed Roles and Features for all Controllers
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -766,8 +766,8 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CSV [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Wi\hich\af2\dbch\af31505\loch\f2 ll create a CSV file for each Appendix.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is False.
+\par \hich\af2\dbch\af31505\loch\f2         Will create a CSV file for each Appendix.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      The default value is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Output CSV filename is in the format:
 \par 
@@ -800,33 +800,33 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position\hich\af2\dbch\af31505\loch\f2 ?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the d\hich\af2\dbch\af31505\loch\f2 elivery group utilization for the last 7 days
+\par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group ut\hich\af2\dbch\af31505\loch\f2 ilization for the last 7 days
 \par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word and requires
 \par \hich\af2\dbch\af31505\loch\f2         Microsoft Excel to be locally installed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the\hich\af2\dbch\af31505\loch\f2  DeliveryGroupsUtilization parameter causes the report to take a longer
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsU\hich\af2\dbch\af31505\loch\f2 tilization parameter causes the report to take a longer
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                  \hich\af2\dbch\af31505\loch\f2   false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the \hich\af2\dbch\af31505\loch\f2 script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
@@ -1035,12 +1035,12 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an \hich\af2\dbch\af31505\loch\f2 alias of SI.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an al\hich\af2\dbch\af31505\loch\f2 ias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1049,14 +1049,14 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String>
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Processes a specific section of the report.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Processes a specific section of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
 \par \hich\af2\dbch\af31505\loch\f2                 AppDisks
 \par \hich\af2\dbch\af31505\loch\f2                 AppDNA
 \par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications and Application Group Details)
 \par \hich\af2\dbch\af31505\loch\f2                 AppV
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Catalogs (Machine Catalogs)
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         Catalogs (Machine Catalogs)
 \par \hich\af2\dbch\af31505\loch\f2                 Config (Configuration)
 \par \hich\af2\dbch\af31505\loch\f2                 Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Groups (Delivery Groups)
@@ -1121,21 +1121,21 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -VDARegistryKeys [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds information on registry keys to the Machine Details section.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Adds information on registry keys to the Machine Details section.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If this parameter is used, MachineCatalogs is set to True.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of VRK.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?        \hich\af2\dbch\af31505\loch\f2             false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email\hich\af2\dbch\af31505\loch\f2  server to send the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email ser\hich\af2\dbch\af31505\loch\f2 ver to send the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1144,7 +1144,7 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Specifies the SMTP port.
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -1202,10 +1202,9 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory_V2.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.34
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2653562 \hich\af2\dbch\af31505\loch\f2 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960\charrsid6054960 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: May }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10580546 \hich\af2\dbch\af31505\loch\f2 8}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960\charrsid6054960 \hich\af2\dbch\af31505\loch\f2 
-, 2020
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2653562 \hich\af2\dbch\af31505\loch\f2 July 1, 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960\charrsid6054960 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1672,21 +1671,21 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -----\hich\af2\dbch\af31505\loch\f2 --------------------- EXAMPLE 26 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" o\hich\af2\dbch\af31505\loch\f2 r
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKE\hich\af2\dbch\af31505\loch\f2 Y_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date\hich\af2\dbch\af31505\loch\f2  time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time sta\hich\af2\dbch\af31505\loch\f2 mp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2020-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2020-06-01_1800.docx
@@ -1708,7 +1707,7 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date t\hich\af2\dbch\af31505\loch\f2 ime stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2020 at 6PM is 2020-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2020-06-01_1800.pdf
@@ -1716,14 +1715,14 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE\hich\af2\dbch\af31505\loch\f2  28 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsof\hich\af2\dbch\af31505\loch\f2 t\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1954,12 +1953,12 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960 \hich\af2\dbch\af31505\loch\f2  HYP\hich\af2\dbch\af31505\loch\f2 ERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6054960\charrsid6054960 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6054960\charrsid6054960 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960\charrsid6054960 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https:\hich\af2\dbch\af31505\loch\f2 //support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6054960\charrsid6054960 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000072}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6054960\charrsid6054960 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960\charrsid6054960 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
@@ -1986,7 +1985,7 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 ctices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300002d}}}{\fldrslt {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid6054960\charrsid6054960 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}
 }}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6054960\charrsid6054960 
 \par 
@@ -2161,10 +2160,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000108f
-c4146c25d60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000108fc4146c25d601
-108fc4146c25d60100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000108fc4146c25
-d601108fc4146c25d6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e50000000000000000000000000099
+d4e3a44fd60103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff0200000000000000000000000000000000000000000000000099d4e3a44fd601
+0099d4e3a44fd60100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff0300000000000000000000000000000000000000000000000099d4e3a44f
+d6010099d4e3a44fd6010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -3,6 +3,16 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
+#Version 2.35 1-JUL-2020
+#	THIS IS THE FINAL UPDATE FOR THE V2 SCRIPT, except for bug fixes
+#	Added new Computer policy settings for CVAD 2006
+#		ICA\Virtual channel white list
+#	Added new User policy settings for CVAD 2006
+#		ICA\Keyboard and IME\Client keyboard layout synchronization and IME improvement
+#		ICA\Keyboard and IME\Enable Unicode keyboard layout mapping
+#		ICA\Keyboard and IME\Hide keyboard layout switch pop-up message box
+#	Added version 7.26 equals 2006
+
 #Version 2.34 8-May-2020
 #	Add checking for a Word version of 0, which indicates the Office installation needs repairing
 #	Add Receive Side Scaling setting to Function OutputNICItem


### PR DESCRIPTION
#Version 2.35 1-JUL-2020
#	THIS IS THE FINAL UPDATE FOR THE V2 SCRIPT, except for bug fixes
#	Added new Computer policy settings for CVAD 2006
#		ICA\Virtual channel white list
#	Added new User policy settings for CVAD 2006
#		ICA\Keyboard and IME\Client keyboard layout synchronization and IME improvement
#		ICA\Keyboard and IME\Enable Unicode keyboard layout mapping
#		ICA\Keyboard and IME\Hide keyboard layout switch pop-up message box
#	Added version 7.26 equals 2006