### PR TITLE
Final update for 2.49

### DIFF
--- a/XD7_Inventory_V2.ps1
+++ b/XD7_Inventory_V2.ps1
@@ -314,8 +314,8 @@
 .PARAMETER AddDateTime
 	Adds a date timestamp to the end of the file name.
 	The timestamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2022 at 6PM is 2022-06-01_1800.
-	Output filename will be ReportName_2022-06-01_1800.docx (or .pdf).
+	June 1, 2022, at 6PM is 2022-06-01_1800.
+	The output filename will be ReportName_2022-06-01_1800.docx (or .pdf).
 	This parameter is disabled by default.
 	This parameter has an alias of ADT.
 .PARAMETER CSV
@@ -508,7 +508,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	The computer running the script for the AdminAddress.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -AdminAddress DDC01
@@ -521,7 +521,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	DDC01 for the AdminAddress.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -PDF
@@ -534,7 +534,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	The computer running the script for the AdminAddress.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -TEXT
@@ -556,7 +556,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -DeliveryGroups
 	
@@ -569,7 +569,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -DeliveryGroupsUtilization
 	
@@ -582,7 +582,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -DeliveryGroups -MachineCatalogs
 	
@@ -596,7 +596,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Applications
 	
@@ -609,7 +609,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Policies
 	
@@ -622,7 +622,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -NoPolicies
 	
@@ -635,7 +635,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -NoADPolicies
 	
@@ -648,7 +648,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Policies -NoADPolicies
 	
@@ -663,7 +663,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Administrators
 	
@@ -677,7 +677,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Logging -StartDate 06/01/2022 -EndDate 
 	06/31/2022	
@@ -693,7 +693,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Logging -StartDate "06/01/2022 10:00:00" 
 	-EndDate "06/01/2022 14:00:00"	
@@ -711,7 +711,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Hosting
 	
@@ -724,7 +724,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -StoreFront
 	
@@ -737,7 +737,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -MachineCatalogs -DeliveryGroups -Applications 
 	-Policies -Hosting -StoreFront	
@@ -758,7 +758,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -MC -DG -Apps -Policies -Hosting
 	
@@ -777,7 +777,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting" 
 	-CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
@@ -785,7 +785,7 @@
 	Uses:
 		Carl Webster Consulting for the Company Name.
 		Mod for the Cover Page format.
-		Carl Webster for the User Name.
+		Carl Webster for the Username.
 		Controller named DDC01 for the AdminAddress.
 .EXAMPLE
 	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod" 
@@ -794,7 +794,7 @@
 	Uses:
 		Carl Webster Consulting for the Company Name (alias CN).
 		Mod for the Cover Page format (alias CP).
-		Carl Webster for the User Name (alias UN).
+		Carl Webster for the Username (alias UN).
 		The computer running the script for the AdminAddress.
 .EXAMPLE
 	PS C:\PSScript .\XD7_Inventory_V2.ps1 -CompanyName "Sherlock Holmes Consulting" 
@@ -804,7 +804,7 @@
 	Uses:
 		Sherlock Holmes Consulting for the Company Name.
 		Exposure for the Cover Page format.
-		Dr. Watson for the User Name.
+		Dr. Watson for the Username.
 		221B Baker Street, London, England for the Company Address.
 		+44 1753 276600 for the Company Fax.
 		+44 1753 276200 for the Company Phone.
@@ -815,7 +815,7 @@
 	Uses:
 		Sherlock Holmes Consulting for the Company Name.
 		Facet for the Cover Page format.
-		Dr. Watson for the User Name.
+		Dr. Watson for the Username.
 		SuperSleuth@SherlockHolmes.com for the Company Email.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -AddDateTime
@@ -828,12 +828,12 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 
 	Adds a date time stamp to the end of the file name.
 	The timestamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2022 at 6PM is 2022-06-01_1800.
-	Output filename will be XD7SiteName_2022-06-01_1800.docx
+	June 1, 2022, at 6PM is 2022-06-01_1800.
+	The output filename will be XD7SiteName_2022-06-01_1800.docx
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -PDF -AddDateTime
 	
@@ -845,12 +845,12 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 
 	Adds a date time stamp to the end of the file name.
 	The timestamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2022 at 6PM is 2022-06-01_1800.
-	Output filename will be XD7SiteName_2022-06-01_1800.pdf
+	June 1, 2022, at 6PM is 2022-06-01_1800.
+	The output filename will be XD7SiteName_2022-06-01_1800.pdf
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Hardware
 	
@@ -862,7 +862,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Folder \\FileServer\ShareName
 	
@@ -874,9 +874,9 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	
-	Output file is saved in the path \\FileServer\ShareName
+	The output file is saved in the path \\FileServer\ShareName
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Section Policies
 	
@@ -888,7 +888,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	Processes only the Policies section of the report.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Section Groups -DG
@@ -901,7 +901,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	Processes only the Delivery Groups section of the report with Delivery Group details.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -Section Groups
@@ -914,7 +914,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	Processes only the Delivery Groups section of the report with no Delivery Group details.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -BrokerRegistryKeys
@@ -929,7 +929,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	Adds the information on over 300 Broker registry keys to the Controllers section.
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory_V2.ps1 -VDARegistryKeys
@@ -942,7 +942,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	Adds the information on VDA registry keys to Appendix A.
 	Forces the MachineCatalogs parameter to $True
 .EXAMPLE
@@ -956,7 +956,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	
 	Set the following parameter values:
 		Administrators      = True
@@ -989,7 +989,7 @@
 
 	Carl Webster for the Company Name.
 	Sideline for the Cover Page format.
-	Administrator for the User Name.
+	Administrator for the Username.
 	
 	Creates a text file named XAXDV2InventoryScriptErrors_yyyyMMddTHHmmssffff.txt that 
 	contains up to the last 250 errors reported by the script.
@@ -1087,9 +1087,9 @@
 	This script creates a Word, PDF, plain text, or HTML document.
 .NOTES
 	NAME: XD7_Inventory_V2.ps1
-	VERSION: 2.48
+	VERSION: 2.49
 	AUTHOR: Carl Webster
-	LASTEDIT: April 26, 2022
+	LASTEDIT: Juy 16, 2022
 #>
 
 #endregion
@@ -1293,6 +1293,15 @@ Param(
 
 # This script is based on the 1.20 script
 
+#Version 2.49 16-Jul-2022
+#	Fixed bug reported by James Rankin where in Function OutputDatastores I didn't check for SQLServerName,TCPPortNumber
+#		https://support.citrix.com/article/CTX234610/how-to-configure-xendesktop-to-use-custom-sql-port
+#		For example, to to [sic] add custom port to the connection strings, then set the $ServerName variable to "DBServername\Instance,CustomPortNumber".
+#		Also fixed a bug where if unable to connect to the SQL server, that error was not handled and many variables were then not defined
+#	Updated Function GetDBCompatibilityLevel to support SQL Server 2022
+#	Updated the help text
+#	Updated the ReadMe file
+#
 #Version 2.48 26-Apr-2022
 #	Fixed text output for hardware inventory
 #	General code cleanup
@@ -2498,9 +2507,9 @@ $PSDefaultParameterValues = @{"*:Verbose"=$True}
 $SaveEAPreference = $ErrorActionPreference
 $ErrorActionPreference = 'SilentlyContinue'
 
-$script:MyVersion           = '2.48'
+$script:MyVersion           = '2.49'
 $Script:ScriptName          = "XD7_Inventory_V2.ps1"
-$tmpdate                    = [datetime] "04/26/2022"
+$tmpdate                    = [datetime] "07/16/2022"
 $Script:ReleaseDate         = $tmpdate.ToUniversalTime().ToShortDateString()
 
 If($Null -eq $MSWord)
@@ -7054,7 +7063,7 @@ Function ShowScriptOptions
 	Write-Verbose "$(Get-Date -Format G): Title              : $($Script:Title)"
 	Write-Verbose "$(Get-Date -Format G): To                 : $($To)"
 	Write-Verbose "$(Get-Date -Format G): Use SSL            : $($UseSSL)"
-	Write-Verbose "$(Get-Date -Format G): User Name          : $($UserName)"
+	Write-Verbose "$(Get-Date -Format G): Username           : $($UserName)"
 	Write-Verbose "$(Get-Date -Format G): VDA Registry Keys  : $($VDARegistryKeys)"
 	Write-Verbose "$(Get-Date -Format G): XA/XD Version      : $($Script:XDSiteVersion)"
 	Write-Verbose "$(Get-Date -Format G): "
@@ -32717,6 +32726,7 @@ Function GetSQLVersion
 Function GetDBCompatibilityLevel
 {
 	Param([string]$DBCompat, [object]$SQLsrv)
+	#9-Jul-2022 add support for SQL Server 2022
 
 	$Major = $SQLsrv.VersionMajor
 	
@@ -32724,6 +32734,7 @@ Function GetDBCompatibilityLevel
 		https://www.spiria.com/en/blog/web-applications/understanding-sql-server-compatibility-levels
 		
 		Database Compatibility Level	Description
+		160								SQL Server 2022
 		150								SQL Server 2019
 		140								SQL Server 2017
 		130								SQL Server 2016	
@@ -32737,6 +32748,7 @@ Function GetDBCompatibilityLevel
 	$tmp = ""
 	Switch($DBCompat)
 	{
+		"160"			{$tmp = "SQL Server 2022"; Break}
 		"150"			{$tmp = "SQL Server 2019"; Break}
 		"140"			{$tmp = "SQL Server 2017"; Break}
 		"130"			{$tmp = "SQL Server 2016"; Break}
@@ -32759,7 +32771,11 @@ Function GetDBCompatibilityLevel
 	#now do a specific test for Azure SQL
 	#https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-2017
 	
-	If($Major -eq 12 -and (($DBCompat -eq 130 -or $DBCompat -eq "Version130") -or ($DBCompat -eq 140 -or $DBCompat -eq "Version140") -or ($DBCompat -eq 150 -or $DBCompat -eq "Version150")))
+	If($Major -eq 12 -and `
+	(($DBCompat -eq 130 -or $DBCompat -eq "Version130") -or `
+	($DBCompat -eq 140 -or $DBCompat -eq "Version140") -or `
+	($DBCompat -eq 150 -or $DBCompat -eq "Version150") -or `
+	($DBCompat -eq 160 -or $DBCompat -eq "Version160")))
 	{
 		$tmp = "Azure SQL Database"
 	}
@@ -32771,8 +32787,7 @@ Function OutputDatastores
 {
 	#2-Mar-2017 Fix bug reported by P. Ewing
 	#2-Apr-2021 Fix bugs reported M. Foster
-	
-	#V2.11 add additional database details and change from a horizontal table to a vertical table
+	#4-Jul-2022 Fix bug reported by James Rankin
 	
 	#line starts with server=SQLServerName;
 	#only need what is between the = and ;
@@ -32780,7 +32795,7 @@ Function OutputDatastores
 	#24-Jun-2017 add Database Size to the output
 	#25-Jun-2017 add checking if the SQL Server assembly loaded before calculating the database size
 	
-	#V2.15 added get IP address for each SQL Server name
+	#add get IP address for each SQL Server name
 	Write-Verbose "$(Get-Date -Format G): `tRetrieving database connection data"
 	Write-Verbose "$(Get-Date -Format G): `t`tConfiguration database"
 	[string]$ConfigSQLServerPrincipalName = ""
@@ -32794,8 +32809,6 @@ Function OutputDatastores
 	$SQLServerNames = @()
 	
 	$ConfigDBs = Get-ConfigDBConnection @XDParams1
-	
-	#add checking for tcp:// and :nnnn
 
 	If($? -and ($Null -ne $ConfigDBs))
 	{
@@ -32821,6 +32834,12 @@ Function OutputDatastores
 			#add in V2.40 get hardware info for the sql server(s)
 			$SQLServerNames += $ConfigSQLServerPrincipalName.Substring(0,$ConfigSQLServerPrincipalName.IndexOf("\"))
 		}
+		ElseIf($ConfigSQLServerPrincipalName.Contains(",")) #3.35
+		{
+			$ConfigSQLServerPrincipalNameIPAddress = Get-IPAddress $ConfigSQLServerPrincipalName.Substring(0,$ConfigSQLServerPrincipalName.IndexOf(","))
+			#add in V2.40 get hardware info for the sql server(s)
+			$SQLServerNames += $ConfigSQLServerPrincipalName.Substring(0,$ConfigSQLServerPrincipalName.IndexOf(","))
+		}
 		ElseIf($ConfigSQLServerPrincipalName -like "*tcp://*")
 		{
 			#looking for tcp://servername.domain.tld:port
@@ -32844,6 +32863,12 @@ Function OutputDatastores
 				$ConfigSQLServerMirrorNameIPAddress = Get-IPAddress $ConfigSQLServerMirrorName.Substring(0,$ConfigSQLServerMirrorName.IndexOf("\"))
 				#add in V2.40 get hardware info for the sql server(s)
 				$SQLServerNames += $ConfigSQLServerMirrorName.Substring(0,$ConfigSQLServerMirrorName.IndexOf("\"))
+			}
+			ElseIf($ConfigSQLServerMirrorName.Contains(",")) #3.35
+			{
+				$ConfigSQLServerMirrorNameIPAddress = Get-IPAddress $ConfigSQLServerMirrorName.Substring(0,$ConfigSQLServerMirrorName.IndexOf(","))
+				#add in V2.40 get hardware info for the sql server(s)
+				$SQLServerNames += $ConfigSQLServerMirrorName.Substring(0,$ConfigSQLServerMirrorName.IndexOf(","))
 			}
 			ElseIf($ConfigSQLServerMirrorName -like "*tcp://*")
 			{
@@ -32870,136 +32895,180 @@ Function OutputDatastores
 		{
 			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($ConfigSQLServerPrincipalName)")
 			$Configdb = New-Object Microsoft.SqlServer.Management.Smo.Database
-			$Configdb = $SQLsrv.Databases.Item("$($ConfigDatabaseName)")
-			[string]$Configdbsize = "Unable to determine" -f $Configdb.size
-			If($Null -ne $Configdb.size)
+			
+			try
 			{
-				[string]$Configdbsize = "{0:F2} MB" -f $Configdb.size
-			}
-			ElseIf($Null -eq $Configdb.size -and $ConfigSQLServerMirrorName -ne "Not Configured")
-			{
-				$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($ConfigSQLServerMirrorName)")
-				$Configdb = New-Object Microsoft.SqlServer.Management.Smo.Database
 				$Configdb = $SQLsrv.Databases.Item("$($ConfigDatabaseName)")
+
+				[string]$Configdbsize = "Unable to determine" -f $Configdb.size
 				If($Null -ne $Configdb.size)
 				{
 					[string]$Configdbsize = "{0:F2} MB" -f $Configdb.size
 				}
-			}
-			
-			$ConfigDBParent 									= $Configdb.Parent
-			$ConfigDBCollation 									= $Configdb.Collation
-			$ConfigDBSQLVersion 								= GetSQLVersion $SQLsrv
-			$ConfigDBCompatibilityLevel 						= GetDBCompatibilityLevel $Configdb.CompatibilityLevel $SQLsrv
-			$ConfigDBCreateDate 								= $Configdb.CreateDate.ToString()
-
-			If($Configdb.IsReadCommittedSnapshotOn)
-			{
-				$ConfigDBReadCommittedSnapshot = "Enabled"
-			}
-			Else
-			{
-				$ConfigDBReadCommittedSnapshot = "Disabled"
-			}
-
-			$ConfigDBLastBackupDate 	= $Configdb.LastBackupDate.ToString()
-			$ConfigDBLastLogBackupDate 	= $Configdb.LastLogBackupDate.ToString()
-			$ConfigDBRecoveryModel 		= $Configdb.RecoveryModel
-
-			If(![String]::IsNullOrEmpty($Configdb.AvailabilityGroupName))
-			{
-				$ConfigDBAvailabilityGroupName 						= $Configdb.AvailabilityGroupName
-				$ConfigDBAvailabilityDatabaseSynchronizationState 	= $Configdb.AvailabilityDatabaseSynchronizationState
-			}
-			Else
-			{
-				$ConfigDBAvailabilityGroupName 						= "-"
-				$ConfigDBAvailabilityDatabaseSynchronizationState 	= "-"
-			}
-			
-			If($Configdb.IsMirroringEnabled)
-			{
-				$ConfigDBMirroringPartner			= $Configdb.MirroringPartner
-				If($Configdb.MirroringPartner.Contains("\"))
+				ElseIf($Null -eq $Configdb.size -and $ConfigSQLServerMirrorName -ne "Not Configured")
 				{
-					$ConfigDBMirroringPartnerIPAddress = Get-IPAddress $Configdb.MirroringPartner.Substring(0,$Configdb.MirroringPartner.IndexOf("\"))
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Configdb.MirroringPartner.Substring(0,$Configdb.MirroringPartner.IndexOf("\"))
+					$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($ConfigSQLServerMirrorName)")
+					$Configdb = New-Object Microsoft.SqlServer.Management.Smo.Database
+					$Configdb = $SQLsrv.Databases.Item("$($ConfigDatabaseName)")
+					If($Null -ne $Configdb.size)
+					{
+						[string]$Configdbsize = "{0:F2} MB" -f $Configdb.size
+					}
 				}
-				ElseIf($Configdb.MirroringPartner -like "*tcp://*")
+				
+				$ConfigDBParent 									= $Configdb.Parent
+				$ConfigDBCollation 									= $Configdb.Collation
+				$ConfigDBSQLVersion 								= GetSQLVersion $SQLsrv
+				$ConfigDBCompatibilityLevel 						= GetDBCompatibilityLevel $Configdb.CompatibilityLevel $SQLsrv
+				$ConfigDBCreateDate 								= $Configdb.CreateDate.ToString()
+
+				If($Configdb.IsReadCommittedSnapshotOn)
 				{
-					#looking for tcp://servername.domain.tld:port
-					$x = $Configdb.MirroringPartner.LastIndexOf("/") + 1 #to get past the //
-					$y = $Configdb.MirroringPartner.LastIndexOf(":")
-					$len = ($y - $x)
-					$ConfigDBMirroringPartnerIPAddress = Get-IPAddress $Configdb.MirroringPartner.Substring($x, $len)
-					$SQLServerNames += $Configdb.MirroringPartner.Substring($x, $len)
+					$ConfigDBReadCommittedSnapshot = "Enabled"
 				}
 				Else
 				{
-					$ConfigDBMirroringPartnerIPAddress = Get-IPAddress $Configdb.MirroringPartner
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Configdb.MirroringPartner
+					$ConfigDBReadCommittedSnapshot = "Disabled"
 				}
-				$ConfigDBMirroringPartnerInstance	= $Configdb.MirroringPartnerInstance
-				$ConfigDBMirroringSafetyLevel		= $Configdb.MirroringSafetyLevel
-				$ConfigDBMirroringStatus			= $Configdb.MirroringStatus
-				$ConfigDBMirroringWitness			= $Configdb.MirroringWitness
-				If($Configdb.MirroringWitness.Contains("\"))
+
+				$ConfigDBLastBackupDate 	= $Configdb.LastBackupDate.ToString()
+				$ConfigDBLastLogBackupDate 	= $Configdb.LastLogBackupDate.ToString()
+				$ConfigDBRecoveryModel 		= $Configdb.RecoveryModel
+
+				If(![String]::IsNullOrEmpty($Configdb.AvailabilityGroupName))
 				{
-					$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness.Substring(0,$Configdb.MirroringWitness.IndexOf("\"))
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Configdb.MirroringWitness.Substring(0,$Configdb.MirroringWitness.IndexOf("\"))
-				}
-				ElseIf($Configdb.MirroringWitness -like "*tcp://*")
-				{
-					#looking for tcp://servername.domain.tld:port
-					$x = $Configdb.MirroringWitness.LastIndexOf("/") + 1 #to get past the //
-					$y = $Configdb.MirroringWitness.LastIndexOf(":")
-					$len = ($y - $x)
-					$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness.Substring($x, $len)
-					$SQLServerNames += $Configdb.MirroringWitness.Substring($x, $len)
+					$ConfigDBAvailabilityGroupName 						= $Configdb.AvailabilityGroupName
+					$ConfigDBAvailabilityDatabaseSynchronizationState 	= $Configdb.AvailabilityDatabaseSynchronizationState
 				}
 				Else
 				{
-					$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Configdb.MirroringWitness
+					$ConfigDBAvailabilityGroupName 						= "-"
+					$ConfigDBAvailabilityDatabaseSynchronizationState 	= "-"
 				}
-				$ConfigDBMirroringWitnessStatus		= $Configdb.MirroringWitnessStatus
-			}
-			Else
-			{
-				$ConfigDBMirroringPartner			= "-"
-				$ConfigDBMirroringPartnerIPAddress	= "-"
-				$ConfigDBMirroringPartnerInstance	= "-"
-				$ConfigDBMirroringSafetyLevel		= "-"
-				$ConfigDBMirroringStatus			= "-"
-				$ConfigDBMirroringWitness			= "-"
-				$ConfigDBMirroringWitnessIPAddress	= "-"
-				$ConfigDBMirroringWitnessStatus		= "-"
+				
+				If($Configdb.IsMirroringEnabled)
+				{
+					$ConfigDBMirroringPartner			= $Configdb.MirroringPartner
+					If($Configdb.MirroringPartner.Contains("\"))
+					{
+						$ConfigDBMirroringPartnerIPAddress = Get-IPAddress $Configdb.MirroringPartner.Substring(0,$Configdb.MirroringPartner.IndexOf("\"))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Configdb.MirroringPartner.Substring(0,$Configdb.MirroringPartner.IndexOf("\"))
+					}
+					ElseIf($Configdb.MirroringPartner.Contains(",")) #3.35
+					{
+						$ConfigDBMirroringPartnerIPAddress = Get-IPAddress $Configdb.MirroringPartner.Substring(0,$Configdb.MirroringPartner.IndexOf(","))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Configdb.MirroringPartner.Substring(0,$Configdb.MirroringPartner.IndexOf(","))
+					}
+					ElseIf($Configdb.MirroringPartner -like "*tcp://*")
+					{
+						#looking for tcp://servername.domain.tld:port
+						$x = $Configdb.MirroringPartner.LastIndexOf("/") + 1 #to get past the //
+						$y = $Configdb.MirroringPartner.LastIndexOf(":")
+						$len = ($y - $x)
+						$ConfigDBMirroringPartnerIPAddress = Get-IPAddress $Configdb.MirroringPartner.Substring($x, $len)
+						$SQLServerNames += $Configdb.MirroringPartner.Substring($x, $len)
+					}
+					Else
+					{
+						$ConfigDBMirroringPartnerIPAddress = Get-IPAddress $Configdb.MirroringPartner
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Configdb.MirroringPartner
+					}
+					$ConfigDBMirroringPartnerInstance	= $Configdb.MirroringPartnerInstance
+					$ConfigDBMirroringSafetyLevel		= $Configdb.MirroringSafetyLevel
+					$ConfigDBMirroringStatus			= $Configdb.MirroringStatus
+					$ConfigDBMirroringWitness			= $Configdb.MirroringWitness
+					If($Configdb.MirroringWitness.Contains("\"))
+					{
+						$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness.Substring(0,$Configdb.MirroringWitness.IndexOf("\"))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Configdb.MirroringWitness.Substring(0,$Configdb.MirroringWitness.IndexOf("\"))
+					}
+					ElseIf($Configdb.MirroringWitness.Contains(",")) #3.35
+					{
+						$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness.Substring(0,$Configdb.MirroringWitness.IndexOf(","))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Configdb.MirroringWitness.Substring(0,$Configdb.MirroringWitness.IndexOf(","))
+					}
+					ElseIf($Configdb.MirroringWitness -like "*tcp://*")
+					{
+						#looking for tcp://servername.domain.tld:port
+						$x = $Configdb.MirroringWitness.LastIndexOf("/") + 1 #to get past the //
+						$y = $Configdb.MirroringWitness.LastIndexOf(":")
+						$len = ($y - $x)
+						$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness.Substring($x, $len)
+						$SQLServerNames += $Configdb.MirroringWitness.Substring($x, $len)
+					}
+					Else
+					{
+						$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Configdb.MirroringWitness
+					}
+					$ConfigDBMirroringWitnessStatus		= $Configdb.MirroringWitnessStatus
+				}
+				Else
+				{
+					$ConfigDBMirroringPartner			= "-"
+					$ConfigDBMirroringPartnerIPAddress	= "-"
+					$ConfigDBMirroringPartnerInstance	= "-"
+					$ConfigDBMirroringSafetyLevel		= "-"
+					$ConfigDBMirroringStatus			= "-"
+					$ConfigDBMirroringWitness			= "-"
+					$ConfigDBMirroringWitnessIPAddress	= "-"
+					$ConfigDBMirroringWitnessStatus		= "-"
+				}
+				
+				#check for log backup status
+				If($ConfigDBRecoveryModel -eq "Simple")
+				{
+					If($ConfigDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
+					{
+						$ConfigDBLastLogBackupDate = "Log backup not needed for Simple Recovery Model"
+					}
+				}
+				ElseIf($ConfigDBRecoveryModel -eq "Full")
+				{
+					If($ConfigDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
+					{
+						$ConfigDBLastLogBackupDate = "Log backup not detected for Full Recovery Model"
+					}
+				}
+				
+				#check for database backup
+				If($ConfigDBLastBackupDate -eq "1/1/0001 12:00:00 AM")
+				{
+					$ConfigDBLastBackupDate = "Database backup not detected"
+				}
 			}
 			
-			#check for log backup status
-			If($ConfigDBRecoveryModel -eq "Simple")
+			catch
 			{
-				If($ConfigDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
-				{
-					$ConfigDBLastLogBackupDate = "Log backup not needed for Simple Recovery Model"
-				}
-			}
-			ElseIf($ConfigDBRecoveryModel -eq "Full")
-			{
-				If($ConfigDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
-				{
-					$ConfigDBLastLogBackupDate = "Log backup not detected for Full Recovery Model"
-				}
-			}
-			
-			#check for database backup
-			If($ConfigDBLastBackupDate -eq "1/1/0001 12:00:00 AM")
-			{
-				$ConfigDBLastBackupDate = "Database backup not detected"
+				$Failure = $Error[0].Exception.Message
+				Write-Warning $Failure
+				$Configdbsize                                     = "Failed to connect to $($ConfigDatabaseName)"
+				$ConfigDBParent 			                      = "Unable to obtain"
+				$ConfigDBCollation 			                      = "Unable to obtain"
+				$ConfigDBSQLVersion 		                      = "Unable to obtain"
+				$ConfigDBCompatibilityLevel                       = "Unable to obtain"
+				$ConfigDBCreateDate 		                      = "Unable to obtain"
+				$ConfigDBReadCommittedSnapshot                    = "Unable to obtain"
+				$ConfigDBLastBackupDate 	                      = "Unable to obtain"
+				$ConfigDBLastLogBackupDate 	                      = "Unable to obtain"
+				$ConfigDBRecoveryModel 	                          = "Unable to obtain"
+				$ConfigDBAvailabilityGroupName 					  = "Unable to obtain"
+				$ConfigDBAvailabilityDatabaseSynchronizationState = "Unable to obtain" 
+				$ConfigDBMirroringPartner			              = "Unable to obtain"
+				$ConfigDBMirroringPartnerIPAddress	              = "Unable to obtain"
+				$ConfigDBMirroringPartnerInstance	              = "Unable to obtain"
+				$ConfigDBMirroringSafetyLevel		              = "Unable to obtain"
+				$ConfigDBMirroringStatus			              = "Unable to obtain"
+				$ConfigDBMirroringWitness			              = "Unable to obtain"
+				$ConfigDBMirroringWitnessIPAddress	              = "Unable to obtain"
+				$ConfigDBMirroringWitnessStatus		              = "Unable to obtain"
+				
 			}
 		}
 	}
@@ -33017,7 +33086,7 @@ Function OutputDatastores
 	[string]$LogDBSQLVersion                    = "Unable to determine"
 	[string]$LogSQLServerPrincipalNameIPAddress = ""
 	[string]$LogSQLServerMirrorNameIPAddress    = ""
-
+	
 	$LogDBs = Get-LogDataStore @XDParams1
 
 	If($? -and ($Null -ne $LogDBs))
@@ -33050,6 +33119,12 @@ Function OutputDatastores
 			#add in V2.40 get hardware info for the sql server(s)
 			$SQLServerNames += $LogSQLServerPrincipalName.Substring(0,$LogSQLServerPrincipalName.IndexOf("\"))
 		}
+		ElseIf($LogSQLServerPrincipalName.Contains(",")) #3.35
+		{
+			$LogSQLServerPrincipalNameIPAddress = Get-IPAddress $LogSQLServerPrincipalName.Substring(0,$LogSQLServerPrincipalName.IndexOf(","))
+			#add in V2.40 get hardware info for the sql server(s)
+			$SQLServerNames += $LogSQLServerPrincipalName.Substring(0,$LogSQLServerPrincipalName.IndexOf(","))
+		}
 		ElseIf($LogSQLServerPrincipalName -like "*tcp://*")
 		{
 			#looking for tcp://servername.domain.tld:port
@@ -33073,6 +33148,12 @@ Function OutputDatastores
 				$LogSQLServerMirrorNameIPAddress = Get-IPAddress $LogSQLServerMirrorName.Substring(0,$LogSQLServerMirrorName.IndexOf("\"))
 				#add in V2.40 get hardware info for the sql server(s)
 				$SQLServerNames += $LogSQLServerMirrorName.Substring(0,$LogSQLServerMirrorName.IndexOf("\"))
+			}
+			ElseIf($LogSQLServerMirrorName.Contains(",")) #3.35
+			{
+				$LogSQLServerMirrorNameIPAddress = Get-IPAddress $LogSQLServerMirrorName.Substring(0,$LogSQLServerMirrorName.IndexOf(","))
+				#add in V2.40 get hardware info for the sql server(s)
+				$SQLServerNames += $LogSQLServerMirrorName.Substring(0,$LogSQLServerMirrorName.IndexOf(","))
 			}
 			ElseIf($LogSQLServerMirrorName -like "*tcp://*")
 			{
@@ -33099,136 +33180,180 @@ Function OutputDatastores
 		{
 			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($LogSQLServerPrincipalName)")
 			$Logdb = New-Object Microsoft.SqlServer.Management.Smo.Database
-			$Logdb = $SQLsrv.Databases.Item("$($LogDatabaseName)")
-			[string]$Logdbsize = "Unable to determine" -f $Logdb.size
-			If($Null -ne $Logdb.size)
+			
+			try
 			{
-				[string]$Logdbsize = "{0:F2} MB" -f $Logdb.size
-			}
-			ElseIf($Null -eq $Logdb.size -and $LogSQLServerMirrorName -ne "Not Configured")
-			{
-				$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($LogSQLServerMirrorName)")
-				$Logdb = New-Object Microsoft.SqlServer.Management.Smo.Database
 				$Logdb = $SQLsrv.Databases.Item("$($LogDatabaseName)")
+
+				[string]$Logdbsize = "Unable to determine" -f $Logdb.size
 				If($Null -ne $Logdb.size)
 				{
 					[string]$Logdbsize = "{0:F2} MB" -f $Logdb.size
 				}
-			}
-
-			$LogDBParent			 = $LogDB.Parent
-			$LogDBCollation			 = $LogDB.Collation
-			$LogDBSQLVersion		 = GetSQLVersion $SQLsrv
-			$LogDBCompatibilityLevel = GetDBCompatibilityLevel $LogDB.CompatibilityLevel $SQLsrv
-			$LogDBCreateDate		 = $LogDB.CreateDate.ToString()
-
-			If($LogDB.IsReadCommittedSnapshotOn)
-			{
-				$LogDBReadCommittedSnapshot = "Enabled"
-			}
-			Else
-			{
-				$LogDBReadCommittedSnapshot = "Disabled"
-			}
-
-			$LogDBLastBackupDate 	= $LogDB.LastBackupDate.ToString()
-			$LogDBLastLogBackupDate	= $LogDB.LastLogBackupDate.ToString()
-			$LogDBRecoveryModel 	= $LogDB.RecoveryModel
-
-			If(![String]::IsNullOrEmpty($LogDB.AvailabilityGroupName))
-			{
-				$LogDBAvailabilityGroupName 					= $LogDB.AvailabilityGroupName
-				$LogDBAvailabilityDatabaseSynchronizationState 	= $LogDB.AvailabilityDatabaseSynchronizationState
-			}
-			Else
-			{
-				$LogDBAvailabilityGroupName 					= "-"
-				$LogDBAvailabilityDatabaseSynchronizationState 	= "-"
-			}
-			
-			If($LogDB.IsMirroringEnabled)
-			{
-				$LogDBMirroringPartner			= $LogDB.MirroringPartner
-				If($Logdb.MirroringPartner.Contains("\"))
+				ElseIf($Null -eq $Logdb.size -and $LogSQLServerMirrorName -ne "Not Configured")
 				{
-					$LogDBMirroringPartnerIPAddress = Get-IPAddress $Logdb.MirroringPartner.Substring(0,$Logdb.MirroringPartner.IndexOf("\"))
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Logdb.MirroringPartner.Substring(0,$Logdb.MirroringPartner.IndexOf("\"))
+					$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($LogSQLServerMirrorName)")
+					$Logdb = New-Object Microsoft.SqlServer.Management.Smo.Database
+					$Logdb = $SQLsrv.Databases.Item("$($LogDatabaseName)")
+					If($Null -ne $Logdb.size)
+					{
+						[string]$Logdbsize = "{0:F2} MB" -f $Logdb.size
+					}
 				}
-				ElseIf($Logdb.MirroringPartner -like "*tcp://*")
+
+				$LogDBParent			 = $LogDB.Parent
+				$LogDBCollation			 = $LogDB.Collation
+				$LogDBSQLVersion		 = GetSQLVersion $SQLsrv
+				$LogDBCompatibilityLevel = GetDBCompatibilityLevel $LogDB.CompatibilityLevel $SQLsrv
+				$LogDBCreateDate		 = $LogDB.CreateDate.ToString()
+
+				If($LogDB.IsReadCommittedSnapshotOn)
 				{
-					#looking for tcp://servername.domain.tld:port
-					$x = $Logdb.MirroringPartner.LastIndexOf("/") + 1 #to get past the //
-					$y = $Logdb.MirroringPartner.LastIndexOf(":")
-					$len = ($y - $x)
-					$LogDBMirroringPartnerIPAddress = Get-IPAddress $Logdb.MirroringPartner.Substring($x, $len)
-					$SQLServerNames += $Logdb.MirroringPartner.Substring($x, $len)
+					$LogDBReadCommittedSnapshot = "Enabled"
 				}
 				Else
 				{
-					$LogDBMirroringPartnerIPAddress = Get-IPAddress $Logdb.MirroringPartner
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Logdb.MirroringPartner
+					$LogDBReadCommittedSnapshot = "Disabled"
 				}
-				$LogDBMirroringPartnerInstance	= $LogDB.MirroringPartnerInstance
-				$LogDBMirroringSafetyLevel		= $LogDB.MirroringSafetyLevel
-				$LogDBMirroringStatus			= $LogDB.MirroringStatus
-				$LogDBMirroringWitness			= $LogDB.MirroringWitness
-				If($Logdb.MirroringWitness.Contains("\"))
+
+				$LogDBLastBackupDate 	= $LogDB.LastBackupDate.ToString()
+				$LogDBLastLogBackupDate	= $LogDB.LastLogBackupDate.ToString()
+				$LogDBRecoveryModel 	= $LogDB.RecoveryModel
+
+				If(![String]::IsNullOrEmpty($LogDB.AvailabilityGroupName))
 				{
-					$LogDBMirroringWitnessIPAddress = Get-IPAddress $Logdb.MirroringWitness.Substring(0,$Logdb.MirroringWitness.IndexOf("\"))
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Logdb.MirroringWitness.Substring(0,$Logdb.MirroringWitness.IndexOf("\"))
-				}
-				ElseIf($Logdb.MirroringWitness -like "*tcp://*")
-				{
-					#looking for tcp://servername.domain.tld:port
-					$x = $Logdb.MirroringWitness.LastIndexOf("/") + 1 #to get past the //
-					$y = $Logdb.MirroringWitness.LastIndexOf(":")
-					$len = ($y - $x)
-					$LogDBMirroringWitnessIPAddress = Get-IPAddress $Logdb.MirroringWitness.Substring($x, $len)
-					$SQLServerNames += $Logdb.MirroringWitness.Substring($x, $len)
+					$LogDBAvailabilityGroupName 					= $LogDB.AvailabilityGroupName
+					$LogDBAvailabilityDatabaseSynchronizationState 	= $LogDB.AvailabilityDatabaseSynchronizationState
 				}
 				Else
 				{
-					$LogDBMirroringWitnessIPAddress = Get-IPAddress $Logdb.MirroringWitness
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Logdb.MirroringWitness
+					$LogDBAvailabilityGroupName 					= "-"
+					$LogDBAvailabilityDatabaseSynchronizationState 	= "-"
 				}
-				$LogDBMirroringWitnessStatus	= $LogDB.MirroringWitnessStatus
-			}
-			Else
-			{
-				$LogDBMirroringPartner			= "-"
-				$LogDBMirroringPartnerIPAddress	= "-"
-				$LogDBMirroringPartnerInstance	= "-"
-				$LogDBMirroringSafetyLevel		= "-"
-				$LogDBMirroringStatus			= "-"
-				$LogDBMirroringWitness			= "-"
-				$LogDBMirroringWitnessIPAddress	= "-"
-				$LogDBMirroringWitnessStatus	= "-"
+				
+				If($LogDB.IsMirroringEnabled)
+				{
+					$LogDBMirroringPartner			= $LogDB.MirroringPartner
+					If($Logdb.MirroringPartner.Contains("\"))
+					{
+						$LogDBMirroringPartnerIPAddress = Get-IPAddress $Logdb.MirroringPartner.Substring(0,$Logdb.MirroringPartner.IndexOf("\"))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Logdb.MirroringPartner.Substring(0,$Logdb.MirroringPartner.IndexOf("\"))
+					}
+					ElseIf($Logdb.MirroringPartner.Contains(",")) #3.35
+					{
+						$LogDBMirroringPartnerIPAddress = Get-IPAddress $Logdb.MirroringPartner.Substring(0,$Logdb.MirroringPartner.IndexOf(","))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Logdb.MirroringPartner.Substring(0,$Logdb.MirroringPartner.IndexOf(","))
+					}
+					ElseIf($Logdb.MirroringPartner -like "*tcp://*")
+					{
+						#looking for tcp://servername.domain.tld:port
+						$x = $Logdb.MirroringPartner.LastIndexOf("/") + 1 #to get past the //
+						$y = $Logdb.MirroringPartner.LastIndexOf(":")
+						$len = ($y - $x)
+						$LogDBMirroringPartnerIPAddress = Get-IPAddress $Logdb.MirroringPartner.Substring($x, $len)
+						$SQLServerNames += $Logdb.MirroringPartner.Substring($x, $len)
+					}
+					Else
+					{
+						$LogDBMirroringPartnerIPAddress = Get-IPAddress $Logdb.MirroringPartner
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Logdb.MirroringPartner
+					}
+					$LogDBMirroringPartnerInstance	= $LogDB.MirroringPartnerInstance
+					$LogDBMirroringSafetyLevel		= $LogDB.MirroringSafetyLevel
+					$LogDBMirroringStatus			= $LogDB.MirroringStatus
+					$LogDBMirroringWitness			= $LogDB.MirroringWitness
+					If($Logdb.MirroringWitness.Contains("\"))
+					{
+						$LogDBMirroringWitnessIPAddress = Get-IPAddress $Logdb.MirroringWitness.Substring(0,$Logdb.MirroringWitness.IndexOf("\"))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Logdb.MirroringWitness.Substring(0,$Logdb.MirroringWitness.IndexOf("\"))
+					}
+					ElseIf($Logdb.MirroringWitness.Contains(",")) #3.35
+					{
+						$LogDBMirroringWitnessIPAddress = Get-IPAddress $Logdb.MirroringWitness.Substring(0,$Logdb.MirroringWitness.IndexOf(","))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Logdb.MirroringWitness.Substring(0,$Logdb.MirroringWitness.IndexOf(","))
+					}
+					ElseIf($Logdb.MirroringWitness -like "*tcp://*")
+					{
+						#looking for tcp://servername.domain.tld:port
+						$x = $Logdb.MirroringWitness.LastIndexOf("/") + 1 #to get past the //
+						$y = $Logdb.MirroringWitness.LastIndexOf(":")
+						$len = ($y - $x)
+						$LogDBMirroringWitnessIPAddress = Get-IPAddress $Logdb.MirroringWitness.Substring($x, $len)
+						$SQLServerNames += $Logdb.MirroringWitness.Substring($x, $len)
+					}
+					Else
+					{
+						$LogDBMirroringWitnessIPAddress = Get-IPAddress $Logdb.MirroringWitness
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Logdb.MirroringWitness
+					}
+					$LogDBMirroringWitnessStatus	= $LogDB.MirroringWitnessStatus
+				}
+				Else
+				{
+					$LogDBMirroringPartner			= "-"
+					$LogDBMirroringPartnerIPAddress	= "-"
+					$LogDBMirroringPartnerInstance	= "-"
+					$LogDBMirroringSafetyLevel		= "-"
+					$LogDBMirroringStatus			= "-"
+					$LogDBMirroringWitness			= "-"
+					$LogDBMirroringWitnessIPAddress	= "-"
+					$LogDBMirroringWitnessStatus	= "-"
+				}
+
+				#check for log backup status
+				If($LogDBRecoveryModel -eq "Simple")
+				{
+					If($LogDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
+					{
+						$LogDBLastLogBackupDate = "Log backup not needed for Simple Recovery Model"
+					}
+				}
+				ElseIf($LogDBRecoveryModel -eq "Full")
+				{
+					If($LogDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
+					{
+						$LogDBLastLogBackupDate = "Log backup not detected for Full Recovery Model"
+					}
+				}
+				
+				#check for database backup
+				If($LogDBLastBackupDate -eq "1/1/0001 12:00:00 AM")
+				{
+					$LogDBLastBackupDate = "Database backup not detected"
+				}
 			}
 
-			#check for log backup status
-			If($LogDBRecoveryModel -eq "Simple")
+			catch
 			{
-				If($LogDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
-				{
-					$LogDBLastLogBackupDate = "Log backup not needed for Simple Recovery Model"
-				}
-			}
-			ElseIf($LogDBRecoveryModel -eq "Full")
-			{
-				If($LogDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
-				{
-					$LogDBLastLogBackupDate = "Log backup not detected for Full Recovery Model"
-				}
-			}
-			
-			#check for database backup
-			If($LogDBLastBackupDate -eq "1/1/0001 12:00:00 AM")
-			{
-				$LogDBLastBackupDate = "Database backup not detected"
+				$Failure = $Error[0].Exception.Message
+				Write-Warning $Failure
+				$Logdbsize                                     = "Failed to connect to $($LogDatabaseName)"
+				$LogDBParent 			                       = "Unable to obtain"
+				$LogDBCollation 			                   = "Unable to obtain"
+				$LogDBSQLVersion 		                       = "Unable to obtain"
+				$LogDBCompatibilityLevel                       = "Unable to obtain"
+				$LogDBCreateDate 		                       = "Unable to obtain"
+				$LogDBReadCommittedSnapshot                    = "Unable to obtain"
+				$LogDBLastBackupDate 	                       = "Unable to obtain"
+				$LogDBLastLogBackupDate 	                   = "Unable to obtain"
+				$LogDBRecoveryModel 	                       = "Unable to obtain"
+				$LogDBAvailabilityGroupName 			       = "Unable to obtain"
+				$LogDBAvailabilityDatabaseSynchronizationState = "Unable to obtain" 
+				$LogDBMirroringPartner			               = "Unable to obtain"
+				$LogDBMirroringPartnerIPAddress	               = "Unable to obtain"
+				$LogDBMirroringPartnerInstance	               = "Unable to obtain"
+				$LogDBMirroringSafetyLevel		               = "Unable to obtain"
+				$LogDBMirroringStatus			               = "Unable to obtain"
+				$LogDBMirroringWitness			               = "Unable to obtain"
+				$LogDBMirroringWitnessIPAddress	               = "Unable to obtain"
+				$LogDBMirroringWitnessStatus		           = "Unable to obtain"
+				
 			}
 		}
 	}
@@ -33282,6 +33407,12 @@ Function OutputDatastores
 			#add in V2.40 get hardware info for the sql server(s)
 			$SQLServerNames += $MonitorSQLServerPrincipalName.Substring(0,$MonitorSQLServerPrincipalName.IndexOf("\"))
 		}
+		ElseIf($MonitorSQLServerPrincipalName.Contains(",")) #3.35
+		{
+			$MonitorSQLServerPrincipalNameIPAddress = Get-IPAddress $MonitorSQLServerPrincipalName.Substring(0,$MonitorSQLServerPrincipalName.IndexOf(","))
+			#add in V2.40 get hardware info for the sql server(s)
+			$SQLServerNames += $MonitorSQLServerPrincipalName.Substring(0,$MonitorSQLServerPrincipalName.IndexOf(","))
+		}
 		ElseIf($MonitorSQLServerPrincipalName -like "*tcp://*")
 		{
 			#looking for tcp://servername.domain.tld:port
@@ -33305,6 +33436,12 @@ Function OutputDatastores
 				$MonitorSQLServerMirrorNameIPAddress = Get-IPAddress $MonitorSQLServerMirrorName.Substring(0,$MonitorSQLServerMirrorName.IndexOf("\"))
 				#add in V2.40 get hardware info for the sql server(s)
 				$SQLServerNames += $MonitorSQLServerMirrorName.Substring(0,$MonitorSQLServerMirrorName.IndexOf("\"))
+			}
+			ElseIf($MonitorSQLServerMirrorName.Contains(",")) #3.35
+			{
+				$MonitorSQLServerMirrorNameIPAddress = Get-IPAddress $MonitorSQLServerMirrorName.Substring(0,$MonitorSQLServerMirrorName.IndexOf(","))
+				#add in V2.40 get hardware info for the sql server(s)
+				$SQLServerNames += $MonitorSQLServerMirrorName.Substring(0,$MonitorSQLServerMirrorName.IndexOf(","))
 			}
 			ElseIf($MonitorSQLServerMirrorName -like "*tcp://*")
 			{
@@ -33331,137 +33468,181 @@ Function OutputDatastores
 		{
 			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($MonitorSQLServerPrincipalName)")
 			$Monitordb = New-Object Microsoft.SqlServer.Management.Smo.Database
-			$Monitordb = $SQLsrv.Databases.Item("$($MonitorDatabaseName)")
-			[string]$Monitordbsize = "Unable to determine" -f $Monitordb.size
-			If($Null -ne $Monitordb.size)
+			
+			try
 			{
-				[string]$Monitordbsize = "{0:F2} MB" -f $Monitordb.size
-			}
-			ElseIf($Null -eq $Monitordb.size -and $MonitorSQLServerMirrorName -ne "Not Configured")
-			{
-				$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($MonitorSQLServerMirrorName)")
-				$Monitordb = New-Object Microsoft.SqlServer.Management.Smo.Database
 				$Monitordb = $SQLsrv.Databases.Item("$($MonitorDatabaseName)")
+				
+				[string]$Monitordbsize = "Unable to determine" -f $Monitordb.size
 				If($Null -ne $Monitordb.size)
 				{
 					[string]$Monitordbsize = "{0:F2} MB" -f $Monitordb.size
 				}
-			}
-
-			$MonitorDBParent 				= $MonitorDB.Parent
-			$MonitorDBCollation 			= $MonitorDB.Collation
-			$MonitorDBSQLVersion 			= GetSQLVersion $SQLsrv
-			$MonitorDBCompatibilityLevel	= GetDBCompatibilityLevel $MonitorDB.CompatibilityLevel $SQLsrv
-			$MonitorDBCreateDate 			= $MonitorDB.CreateDate.ToString()
-
-			If($MonitorDB.IsReadCommittedSnapshotOn)
-			{
-				$MonitorDBReadCommittedSnapshot = "Enabled"
-			}
-			Else
-			{
-				$MonitorDBReadCommittedSnapshot = "Disabled"
-			}
-
-			$MonitorDBLastBackupDate 	= $MonitorDB.LastBackupDate.ToString()
-			$MonitorDBLastLogBackupDate	= $MonitorDB.LastLogBackupDate.ToString()
-			$MonitorDBRecoveryModel 	= $MonitorDB.RecoveryModel
-
-			If(![String]::IsNullOrEmpty($MonitorDB.AvailabilityGroupName))
-			{
-				$MonitorDBAvailabilityGroupName 					= $MonitorDB.AvailabilityGroupName
-				$MonitorDBAvailabilityDatabaseSynchronizationState 	= $MonitorDB.AvailabilityDatabaseSynchronizationState
-			}
-			Else
-			{
-				$MonitorDBAvailabilityGroupName 					= "-"
-				$MonitorDBAvailabilityDatabaseSynchronizationState 	= "-"
-			}
-			
-			If($MonitorDB.IsMirroringEnabled)
-			{
-				$MonitorDBMirroringPartner			= $MonitorDB.MirroringPartner
-				If($Monitordb.MirroringPartner.Contains("\"))
+				ElseIf($Null -eq $Monitordb.size -and $MonitorSQLServerMirrorName -ne "Not Configured")
 				{
-					$MonitorDBMirroringPartnerIPAddress = Get-IPAddress $Monitordb.MirroringPartner.Substring(0,$Monitordb.MirroringPartner.IndexOf("\"))
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Monitordb.MirroringPartner.Substring(0,$Monitordb.MirroringPartner.IndexOf("\"))
+					$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($MonitorSQLServerMirrorName)")
+					$Monitordb = New-Object Microsoft.SqlServer.Management.Smo.Database
+					$Monitordb = $SQLsrv.Databases.Item("$($MonitorDatabaseName)")
+					If($Null -ne $Monitordb.size)
+					{
+						[string]$Monitordbsize = "{0:F2} MB" -f $Monitordb.size
+					}
 				}
-				ElseIf($Monitordb.MirroringPartner -like "*tcp://*")
+
+				$MonitorDBParent 				= $MonitorDB.Parent
+				$MonitorDBCollation 			= $MonitorDB.Collation
+				$MonitorDBSQLVersion 			= GetSQLVersion $SQLsrv
+				$MonitorDBCompatibilityLevel	= GetDBCompatibilityLevel $MonitorDB.CompatibilityLevel $SQLsrv
+				$MonitorDBCreateDate 			= $MonitorDB.CreateDate.ToString()
+
+				If($MonitorDB.IsReadCommittedSnapshotOn)
 				{
-					#looking for tcp://servername.domain.tld:port
-					$x = $Monitordb.MirroringPartner.LastIndexOf("/") + 1 #to get past the //
-					$y = $Monitordb.MirroringPartner.LastIndexOf(":")
-					$len = ($y - $x)
-					$MonitorDBMirroringPartnerIPAddress = Get-IPAddress $Monitordb.MirroringPartner.Substring($x, $len)
-					$SQLServerNames += $Monitordb.MirroringPartner.Substring($x, $len)
+					$MonitorDBReadCommittedSnapshot = "Enabled"
 				}
 				Else
 				{
-					$MonitorDBMirroringPartnerIPAddress = Get-IPAddress $Monitordb.MirroringPartner
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $Monitordb.MirroringPartner
+					$MonitorDBReadCommittedSnapshot = "Disabled"
 				}
-				$MonitorDBMirroringPartnerInstance	= $MonitorDB.MirroringPartnerInstance
-				$MonitorDBMirroringSafetyLevel		= $MonitorDB.MirroringSafetyLevel
-				$MonitorDBMirroringStatus			= $MonitorDB.MirroringStatus
-				$MonitorDBMirroringWitness			= $MonitorDB.MirroringWitness
-				If($Monitordb.MirroringWitness.Contains("\"))
+
+				$MonitorDBLastBackupDate 	= $MonitorDB.LastBackupDate.ToString()
+				$MonitorDBLastLogBackupDate	= $MonitorDB.LastLogBackupDate.ToString()
+				$MonitorDBRecoveryModel 	= $MonitorDB.RecoveryModel
+
+				If(![String]::IsNullOrEmpty($MonitorDB.AvailabilityGroupName))
 				{
-					$MonitorDBMirroringWitnessIPAddress = Get-IPAddress $MonitorDB.MirroringWitness.Substring(0,$MonitorDB.MirroringWitness.IndexOf("\"))
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $MonitorDB.MirroringWitness.Substring(0,$MonitorDB.MirroringWitness.IndexOf("\"))
-				}
-				ElseIf($Monitordb.MirroringWitness -like "*tcp://*")
-				{
-					#looking for tcp://servername.domain.tld:port
-					$x = $Monitordb.MirroringWitness.LastIndexOf("/") + 1 #to get past the //
-					$y = $Monitordb.MirroringWitness.LastIndexOf(":")
-					$len = ($y - $x)
-					$MonitorDBMirroringWitnessIPAddress = Get-IPAddress $Monitordb.MirroringWitness.Substring($x, $len)
-					$SQLServerNames += $Monitordb.MirroringWitness.Substring($x, $len)
+					$MonitorDBAvailabilityGroupName 					= $MonitorDB.AvailabilityGroupName
+					$MonitorDBAvailabilityDatabaseSynchronizationState 	= $MonitorDB.AvailabilityDatabaseSynchronizationState
 				}
 				Else
 				{
-					$MonitorDBMirroringWitnessIPAddress = Get-IPAddress $MonitorDB.MirroringWitness
-					#add in V2.40 get hardware info for the sql server(s)
-					$SQLServerNames += $MonitorDB.MirroringWitness
+					$MonitorDBAvailabilityGroupName 					= "-"
+					$MonitorDBAvailabilityDatabaseSynchronizationState 	= "-"
 				}
-				$MonitorDBMirroringWitnessStatus	= $MonitorDB.MirroringWitnessStatus
-			}
-			Else
-			{
-				$MonitorDBMirroringPartner			= "-"
-				$MonitorDBMirroringPartnerIPAddress	= "-"
-				$MonitorDBMirroringPartnerInstance	= "-"
-				$MonitorDBMirroringSafetyLevel		= "-"
-				$MonitorDBMirroringStatus			= "-"
-				$MonitorDBMirroringWitness			= "-"
-				$MonitorDBMirroringWitnessIPAddress	= "-"
-				$MonitorDBMirroringWitnessStatus	= "-"
-			}
+				
+				If($MonitorDB.IsMirroringEnabled)
+				{
+					$MonitorDBMirroringPartner			= $MonitorDB.MirroringPartner
+					If($Monitordb.MirroringPartner.Contains("\"))
+					{
+						$MonitorDBMirroringPartnerIPAddress = Get-IPAddress $Monitordb.MirroringPartner.Substring(0,$Monitordb.MirroringPartner.IndexOf("\"))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Monitordb.MirroringPartner.Substring(0,$Monitordb.MirroringPartner.IndexOf("\"))
+					}
+					ElseIf($Monitordb.MirroringPartner.Contains(",")) #3.35
+					{
+						$MonitorDBMirroringPartnerIPAddress = Get-IPAddress $Monitordb.MirroringPartner.Substring(0,$Monitordb.MirroringPartner.IndexOf(","))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Monitordb.MirroringPartner.Substring(0,$Monitordb.MirroringPartner.IndexOf(","))
+					}
+					ElseIf($Monitordb.MirroringPartner -like "*tcp://*")
+					{
+						#looking for tcp://servername.domain.tld:port
+						$x = $Monitordb.MirroringPartner.LastIndexOf("/") + 1 #to get past the //
+						$y = $Monitordb.MirroringPartner.LastIndexOf(":")
+						$len = ($y - $x)
+						$MonitorDBMirroringPartnerIPAddress = Get-IPAddress $Monitordb.MirroringPartner.Substring($x, $len)
+						$SQLServerNames += $Monitordb.MirroringPartner.Substring($x, $len)
+					}
+					Else
+					{
+						$MonitorDBMirroringPartnerIPAddress = Get-IPAddress $Monitordb.MirroringPartner
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $Monitordb.MirroringPartner
+					}
+					$MonitorDBMirroringPartnerInstance	= $MonitorDB.MirroringPartnerInstance
+					$MonitorDBMirroringSafetyLevel		= $MonitorDB.MirroringSafetyLevel
+					$MonitorDBMirroringStatus			= $MonitorDB.MirroringStatus
+					$MonitorDBMirroringWitness			= $MonitorDB.MirroringWitness
+					If($Monitordb.MirroringWitness.Contains("\"))
+					{
+						$MonitorDBMirroringWitnessIPAddress = Get-IPAddress $MonitorDB.MirroringWitness.Substring(0,$MonitorDB.MirroringWitness.IndexOf("\"))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $MonitorDB.MirroringWitness.Substring(0,$MonitorDB.MirroringWitness.IndexOf("\"))
+					}
+					ElseIf($Monitordb.MirroringWitness.Contains(",")) #3.35
+					{
+						$MonitorDBMirroringWitnessIPAddress = Get-IPAddress $MonitorDB.MirroringWitness.Substring(0,$MonitorDB.MirroringWitness.IndexOf(","))
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $MonitorDB.MirroringWitness.Substring(0,$MonitorDB.MirroringWitness.IndexOf(","))
+					}
+					ElseIf($Monitordb.MirroringWitness -like "*tcp://*")
+					{
+						#looking for tcp://servername.domain.tld:port
+						$x = $Monitordb.MirroringWitness.LastIndexOf("/") + 1 #to get past the //
+						$y = $Monitordb.MirroringWitness.LastIndexOf(":")
+						$len = ($y - $x)
+						$MonitorDBMirroringWitnessIPAddress = Get-IPAddress $Monitordb.MirroringWitness.Substring($x, $len)
+						$SQLServerNames += $Monitordb.MirroringWitness.Substring($x, $len)
+					}
+					Else
+					{
+						$MonitorDBMirroringWitnessIPAddress = Get-IPAddress $MonitorDB.MirroringWitness
+						#add in V2.40 get hardware info for the sql server(s)
+						$SQLServerNames += $MonitorDB.MirroringWitness
+					}
+					$MonitorDBMirroringWitnessStatus	= $MonitorDB.MirroringWitnessStatus
+				}
+				Else
+				{
+					$MonitorDBMirroringPartner			= "-"
+					$MonitorDBMirroringPartnerIPAddress	= "-"
+					$MonitorDBMirroringPartnerInstance	= "-"
+					$MonitorDBMirroringSafetyLevel		= "-"
+					$MonitorDBMirroringStatus			= "-"
+					$MonitorDBMirroringWitness			= "-"
+					$MonitorDBMirroringWitnessIPAddress	= "-"
+					$MonitorDBMirroringWitnessStatus	= "-"
+				}
 
-			#check for log backup status
-			If($MonitorDBRecoveryModel -eq "Simple")
-			{
-				If($MonitorDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
+				#check for log backup status
+				If($MonitorDBRecoveryModel -eq "Simple")
 				{
-					$MonitorDBLastLogBackupDate = "Log backup not needed for Simple Recovery Model"
+					If($MonitorDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
+					{
+						$MonitorDBLastLogBackupDate = "Log backup not needed for Simple Recovery Model"
+					}
 				}
-			}
-			ElseIf($MonitorDBRecoveryModel -eq "Full")
-			{
-				If($MonitorDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
+				ElseIf($MonitorDBRecoveryModel -eq "Full")
 				{
-					$MonitorDBLastLogBackupDate = "Log backup not detected for Full Recovery Model"
+					If($MonitorDBLastLogBackupDate -eq "1/1/0001 12:00:00 AM")
+					{
+						$MonitorDBLastLogBackupDate = "Log backup not detected for Full Recovery Model"
+					}
+				}
+				
+				#check for database backup
+				If($MonitorDBLastBackupDate -eq "1/1/0001 12:00:00 AM")
+				{
+					$MonitorDBLastBackupDate = "Database backup not detected"
 				}
 			}
 			
-			#check for database backup
-			If($MonitorDBLastBackupDate -eq "1/1/0001 12:00:00 AM")
+			catch
 			{
-				$MonitorDBLastBackupDate = "Database backup not detected"
+				$Failure = $Error[0].Exception.Message
+				Write-Warning $Failure
+				$Monitordbsize                                     = "Failed to connect to $($MonitorDatabaseName)"
+				$MonitorDBParent 			                       = "Unable to obtain"
+				$MonitorDBCollation 			                   = "Unable to obtain"
+				$MonitorDBSQLVersion 		                       = "Unable to obtain"
+				$MonitorDBCompatibilityLevel                       = "Unable to obtain"
+				$MonitorDBCreateDate 		                       = "Unable to obtain"
+				$MonitorDBReadCommittedSnapshot                    = "Unable to obtain"
+				$MonitorDBLastBackupDate 	                       = "Unable to obtain"
+				$MonitorDBLastLogBackupDate                        = "Unable to obtain"
+				$MonitorDBRecoveryModel 	                       = "Unable to obtain"
+				$MonitorDBAvailabilityGroupName 			       = "Unable to obtain"
+				$MonitorDBAvailabilityDatabaseSynchronizationState = "Unable to obtain" 
+				$MonitorDBMirroringPartner			               = "Unable to obtain"
+				$MonitorDBMirroringPartnerIPAddress	               = "Unable to obtain"
+				$MonitorDBMirroringPartnerInstance	               = "Unable to obtain"
+				$MonitorDBMirroringSafetyLevel		               = "Unable to obtain"
+				$MonitorDBMirroringStatus			               = "Unable to obtain"
+				$MonitorDBMirroringWitness			               = "Unable to obtain"
+				$MonitorDBMirroringWitnessIPAddress	               = "Unable to obtain"
+				$MonitorDBMirroringWitnessStatus		           = "Unable to obtain"
 			}
+
 		}
 		
 		$MonitorConfig = $Null
@@ -33845,7 +34026,7 @@ Function OutputDatastores
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 250;
-			$Table.Columns.Item(2).Width = 200;
+			$Table.Columns.Item(2).Width = 250;
 
 			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
 
@@ -33889,7 +34070,7 @@ Function OutputDatastores
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 250;
-			$Table.Columns.Item(2).Width = 200;
+			$Table.Columns.Item(2).Width = 250;
 
 			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
 
@@ -33933,7 +34114,7 @@ Function OutputDatastores
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 250;
-			$Table.Columns.Item(2).Width = 200;
+			$Table.Columns.Item(2).Width = 250;
 
 			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
 
@@ -34066,9 +34247,8 @@ Function OutputDatastores
 
 			FindWordDocumentEnd
 			$Table = $Null
-			WriteWordLine 0 0 ""
 		}
-		ElseIf($Text)
+		If($Text)
 		{
 			Line 0 "Datastores"
 			Line 0 ""
@@ -34249,7 +34429,7 @@ Function OutputDatastores
 			Line 2 "Summaries`t`t`t: " $MonitorConfig.GroomSummariesRetentionDays
 			Line 0 ""
 		}
-		ElseIf($HTML)
+		If($HTML)
 		{
 			WriteHTMLLine 2 0 "Datastores"
 			
@@ -34281,8 +34461,8 @@ Function OutputDatastores
 			$rowdata += @(,("Server IP Address",($global:htmlsb),$ConfigSQLServerPrincipalNameIPAddress,$htmlwhite))
 			$rowdata += @(,("SQL Server Version",($global:htmlsb),$ConfigDBSQLVersion,$htmlwhite))
 			$msg = ""
-			$columnWidths = @("275","300")
-			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "575"
+			$columnWidths = @("250","275")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "525"
 			WriteHTMLLine 0 0 ""
 			
 			$rowdata = @()
@@ -34313,10 +34493,10 @@ Function OutputDatastores
 			$rowdata += @(,("Server IP Address",($global:htmlsb),$LogSQLServerPrincipalNameIPAddress,$htmlwhite))
 			$rowdata += @(,("SQL Server Version",($global:htmlsb),$LogDBSQLVersion,$htmlwhite))
 			$msg = ""
-			$columnWidths = @("275","300")
-			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "575"
+			$columnWidths = @("250","275")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "525"
 			WriteHTMLLine 0 0 ""
-
+			
 			$rowdata = @()
 			$columnHeaders = @("Datastore",($global:htmlsb),"Monitoring",$htmlwhite)
 			$rowdata += @(,("Database Name",($global:htmlsb),$MonitorDatabaseName,$htmlwhite))
@@ -34345,9 +34525,9 @@ Function OutputDatastores
 			$rowdata += @(,("Server IP Address",($global:htmlsb),$MonitorSQLServerPrincipalNameIPAddress,$htmlwhite))
 			$rowdata += @(,("SQL Server Version",($global:htmlsb),$MonitorDBSQLVersion,$htmlwhite))
 			$msg = ""
-			$columnWidths = @("275","300")
-			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "575"
-
+			$columnWidths = @("250","275")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "525"
+			
 			WriteHTMLLine 3 0 "Monitoring Database Details"
 			$rowdata = @()
 			$columnHeaders = @("Collect Hotfix Data",($global:htmlsb),$MonitorCollectHotfix,$htmlwhite)
@@ -34374,8 +34554,8 @@ Function OutputDatastores
 			$rowdata += @(,('Sync Poll Time Hours',($global:htmlsb),$MonitorConfig.SyncPollTimeHours,$htmlwhite))
 
 			$msg = ""
-			$columnWidths = @("200","50")
-			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "250"
+			$columnWidths = @("250","275")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "525"
 			
 			WriteHTMLLine 3 0 "Groom Retention Settings in Days"
 			$rowdata = @()
@@ -34429,7 +34609,7 @@ Function OutputDatastores
 			{
 				$rowdata += @(,('Machine Metric Day Summary',($global:htmlsb),$MonitorConfig.GroomMachineMetricDaySummaryDataRetentionDays.ToString(),$htmlwhite))
 			}
-			$rowdata += @(,('Minute',($global:htmlsb),$MonitorConfig.GroomMinuteRetentionDays.ToString(),$htmlwhite))
+			$rowdata += @(,('Minute',($global:htmlsb),$MonitorConfig.GroomMinuteRetentionDays,$htmlwhite))
 			If($MonitorConfig.ContainsKey("GroomNotificationLogRetentionDays"))
 			{
 				$rowdata += @(,('Notification',($global:htmlsb),$MonitorConfig.GroomNotificationLogRetentionDays.ToString(),$htmlwhite))
@@ -40528,7 +40708,7 @@ Function ProcessScriptEnd
 		Out-File -FilePath $SIFile -Append -InputObject "Use SSL            : $($UseSSL)" 4>$Null
 		If($MSWORD -or $PDF)
 		{
-			Out-File -FilePath $SIFile -Append -InputObject "User Name          : $($UserName)" 4>$Null
+			Out-File -FilePath $SIFile -Append -InputObject "Username           : $($UserName)" 4>$Null
 		}
 		Out-File -FilePath $SIFile -Append -InputObject "VDA Registry Keys  : $($VDARegistryKeys)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "XA/XD Version      : $($Script:XDSiteVersion)" 4>$Null

--- a/XD7_Inventory_V2_ReadMe.rtf
+++ b/XD7_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -78,29 +78,29 @@ Header Char;}{\s24\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faa
 \leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
-\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid22035\rsid27437\rsid79866\rsid146152\rsid205773\rsid219208\rsid225408\rsid265763\rsid276536\rsid346080\rsid595465\rsid601046\rsid674851\rsid677819
-\rsid742267\rsid865466\rsid928241\rsid1260987\rsid1274375\rsid1575696\rsid1654655\rsid1794844\rsid1857973\rsid2054605\rsid2105709\rsid2243781\rsid2365947\rsid2517006\rsid2579094\rsid2584542\rsid2647325\rsid2650981\rsid2653562\rsid2902416\rsid2978753
-\rsid3097678\rsid3211995\rsid3300860\rsid3351071\rsid3430394\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4143005\rsid4146592\rsid4149699\rsid4213396\rsid4222850\rsid4223135\rsid4357927\rsid4522193\rsid4736307\rsid4740061\rsid4745200\rsid4925283
-\rsid4983150\rsid4993354\rsid5071910\rsid5113752\rsid5207971\rsid5209339\rsid5267713\rsid5583166\rsid5703879\rsid5708053\rsid5847035\rsid5966599\rsid6053627\rsid6054960\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370\rsid7021714
-\rsid7432229\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8217638\rsid8350100\rsid8394203\rsid8410782\rsid8460232\rsid8480737\rsid8596828\rsid8656978\rsid8662784\rsid8784236\rsid8790405\rsid8876191\rsid9004702\rsid9047498\rsid9112866\rsid9137387
-\rsid9140609\rsid9338186\rsid9376723\rsid9520485\rsid9571940\rsid9639341\rsid9665434\rsid9708402\rsid9765064\rsid9974690\rsid9986361\rsid10315109\rsid10381511\rsid10488541\rsid10580546\rsid10900280\rsid10963467\rsid10973072\rsid11041950\rsid11089304
-\rsid11227030\rsid11470767\rsid11488686\rsid11602325\rsid11605034\rsid11801942\rsid11823514\rsid11884716\rsid12058823\rsid12214292\rsid12258164\rsid12271374\rsid12272355\rsid12272564\rsid12344904\rsid12353294\rsid12523992\rsid12541957\rsid12594415
-\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12911697\rsid12917467\rsid12978708\rsid13007581\rsid13064333\rsid13200294\rsid13262982\rsid13390092\rsid13401205\rsid13437246\rsid13510413\rsid13515584\rsid13662136\rsid13831617\rsid13853169
-\rsid13909972\rsid13987238\rsid14097372\rsid14169246\rsid14577313\rsid14684132\rsid14697282\rsid14769514\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid15101847\rsid15422717\rsid15428007\rsid15496272\rsid15613047\rsid15623927\rsid15678052
-\rsid15692337\rsid15739384\rsid15802422\rsid15815800\rsid15873118\rsid15948729\rsid15993668\rsid16021289\rsid16203271\rsid16207041\rsid16258407\rsid16258678\rsid16271519\rsid16272684\rsid16326917\rsid16384472\rsid16473260\rsid16517051\rsid16520077
-\rsid16527420\rsid16597410\rsid16671164}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
-{\revtim\yr2022\mo3\dy26\hr15\min26}{\version129}{\edmins12072}{\nofpages30}{\nofwords9451}{\nofchars53872}{\nofcharsws63197}{\vern43}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid22035\rsid27437\rsid79866\rsid146152\rsid205773\rsid219208\rsid225408\rsid265362\rsid265763\rsid276536\rsid346080\rsid595465\rsid601046\rsid674851
+\rsid677819\rsid742267\rsid865466\rsid928241\rsid1260987\rsid1274375\rsid1575696\rsid1654655\rsid1794844\rsid1857973\rsid2054605\rsid2105709\rsid2243781\rsid2365947\rsid2517006\rsid2579094\rsid2584542\rsid2647325\rsid2650981\rsid2653562\rsid2902416
+\rsid2978753\rsid3097678\rsid3211995\rsid3300860\rsid3351071\rsid3430394\rsid3542051\rsid3760385\rsid3761251\rsid3830441\rsid4143005\rsid4146592\rsid4149699\rsid4213396\rsid4222850\rsid4223135\rsid4357927\rsid4522193\rsid4736307\rsid4740061\rsid4745200
+\rsid4925283\rsid4983150\rsid4993354\rsid5071910\rsid5113752\rsid5207971\rsid5209339\rsid5267713\rsid5583166\rsid5703879\rsid5708053\rsid5847035\rsid5966599\rsid6053627\rsid6054960\rsid6186463\rsid6258287\rsid6316284\rsid6565250\rsid6637724\rsid6947370
+\rsid7021714\rsid7432229\rsid7733837\rsid7763859\rsid7881433\rsid8211820\rsid8217638\rsid8350100\rsid8394203\rsid8410782\rsid8460232\rsid8480737\rsid8596828\rsid8656978\rsid8662784\rsid8784236\rsid8790405\rsid8876191\rsid9004702\rsid9047498\rsid9112866
+\rsid9137387\rsid9140609\rsid9338186\rsid9376723\rsid9520485\rsid9571940\rsid9639341\rsid9665434\rsid9708402\rsid9765064\rsid9974690\rsid9986361\rsid10315109\rsid10381511\rsid10488541\rsid10580546\rsid10900280\rsid10963467\rsid10973072\rsid11041950
+\rsid11078157\rsid11089304\rsid11227030\rsid11470767\rsid11488686\rsid11602325\rsid11605034\rsid11801942\rsid11823514\rsid11884716\rsid12058823\rsid12214292\rsid12258164\rsid12271374\rsid12272355\rsid12272564\rsid12344904\rsid12353294\rsid12523992
+\rsid12541909\rsid12541957\rsid12594415\rsid12602409\rsid12801149\rsid12862757\rsid12863195\rsid12911697\rsid12917467\rsid12978708\rsid13007581\rsid13064333\rsid13200294\rsid13262982\rsid13390092\rsid13401205\rsid13437246\rsid13510413\rsid13515584
+\rsid13662136\rsid13831617\rsid13853169\rsid13909972\rsid13987238\rsid14097372\rsid14169246\rsid14577313\rsid14684132\rsid14697282\rsid14769514\rsid14828264\rsid14881286\rsid14888064\rsid14962568\rsid15101847\rsid15422717\rsid15428007\rsid15496272
+\rsid15613047\rsid15623927\rsid15678052\rsid15692337\rsid15739384\rsid15802422\rsid15815800\rsid15873118\rsid15948729\rsid15993668\rsid16021289\rsid16203271\rsid16207041\rsid16258407\rsid16258678\rsid16271519\rsid16272684\rsid16326917\rsid16384472
+\rsid16473260\rsid16517051\rsid16520077\rsid16527420\rsid16597410\rsid16671164}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2022\mo7\dy16\hr9\min23}{\version130}{\edmins12078}{\nofpages30}{\nofwords9458}{\nofchars53912}{\nofcharsws63244}{\vern51}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBcbmtQC7BHupLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8480737 \chftnsep 
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjI3twRSFoaGxpZmZko6SsGpxcWZ+XkgBcYWtQB0GOMuLQAAAA==}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid265362 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8480737 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid265362 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8480737 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid265362 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16203271 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8480737 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid265362 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s24\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid16203271 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid16203271 
@@ -238,7 +238,7 @@ Install these two files to get information on the SQL Server(s) and database(s).
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 
 By default, a Microsoft Word document is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11488686\charrsid13987238 .
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \hich\af37\dbch\af31505\loch\f37 
 PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 6.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
@@ -374,8 +374,8 @@ rtDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15422717
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid276536 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/" }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid276536 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bce000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}
-}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/}}}\sectd \ltrsect
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0078002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000001}
+}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-x-documentation-script/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If you are running CVAD 2006 and later, please use:
@@ -383,15 +383,15 @@ rtDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15422717
 \hich\af2\dbch\af31505\loch\f2 t/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid276536 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd0000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
 64002d0069006e0066006f002f006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d00760033002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300
-00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-virtual-apps-and-desktops-v3-scrip\hich\af2\dbch\af31505\loch\f2 
-t/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
+0000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-virtual-apps-and-desktops-v3-scrip
+\hich\af2\dbch\af31505\loch\f2 t/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If you are running Citrix Cloud, please use:
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid276536 \hich\af2\dbch\af31505\loch\f2 
  HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid276536 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be6000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
 64002d0069006e0066006f002f006300690074007200690078002d0063006c006f00750064002d006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d0073006500720076006900630065002f000000795881
-f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 
+f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 
 https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     NOTE: The account used to run this script must have\hich\af2\dbch\af31505\loch\f2  at least Read access to the SQL
@@ -848,8 +848,10 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end o\hich\af2\dbch\af31505\loch\f2 f the file name.
 \par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2022 at 6PM is 2022-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2022-06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12541909 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 \hich\af2\dbch\af31505\loch\f2  at 6PM is 2022-06-01_1800.
+
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12541909 \hich\af2\dbch\af31505\loch\f2 The o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 \hich\af2\dbch\af31505\loch\f2 
+utput filename will be ReportName_2022-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter has an alias of ADT.
 \par 
@@ -951,33 +953,33 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wi\hich\af2\dbch\af31505\loch\f2 ldcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Def\hich\af2\dbch\af31505\loch\f2 ault value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF\hich\af2\dbch\af31505\loch\f2  file is roughly 5X to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?\hich\af2\dbch\af31505\loch\f2                     named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                 \hich\af2\dbch\af31505\loch\f2    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page ha\hich\af2\dbch\af31505\loch\f2 s the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address fie\hich\af2\dbch\af31505\loch\f2 ld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
@@ -1182,10 +1184,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVari\hich\af2\dbch\af31505\loch\f2 able, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid11078157 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None. You cannot pipe objects to this script.
+\par \hich\af2\dbch\af31505\loch\f2     None. Yo\hich\af2\dbch\af31505\loch\f2 u cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
@@ -1197,23 +1203,24 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory_V2.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid865466 \hich\af2\dbch\af31505\loch\f2 7}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Ca\hich\af2\dbch\af31505\loch\f2 rl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid865466 \hich\af2\dbch\af31505\loch\f2 March 26, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 July 16, \hich\af2\dbch\af31505\loch\f2 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12058823\charrsid12058823 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Co\hich\af2\dbch\af31505\loch\f2 mpanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1221,17 +1228,17 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Admi\hich\af2\dbch\af31505\loch\f2 nAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -AdminAddress DDC01
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
+\par \hich\af2\dbch\af31505\loch\f2     Uses all default val\hich\af2\dbch\af31505\loch\f2 ues.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Admini\hich\af2\dbch\af31505\loch\f2 strator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Compan\hich\af2\dbch\af31505\loch\f2 y Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
 \par 
 \par 
@@ -1239,23 +1246,23 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_\hich\af2\dbch\af31505\loch\f2 Inventory_V2.ps1 -PDF
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $\hich\af2\dbch\af31505\loch\f2 env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------\hich\af2\dbch\af31505\loch\f2 ------------------- EXAMPLE 4 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -TEXT
 \par 
@@ -1266,7 +1273,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -HTML
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory\hich\af2\dbch\af31505\loch\f2 _V2.ps1 -HTML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as an HTML file.
 \par 
@@ -1279,14 +1286,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT\hich\af2\dbch\af31505\loch\f2 _USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline \hich\af2\dbch\af31505\loch\f2 for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1295,71 +1302,71 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroups
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in \hich\af2\dbch\af31505\loch\f2 all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compan\hich\af2\dbch\af31505\loch\f2 yName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroupsUtilization
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroupsUtilization
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilization details for all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilizati\hich\af2\dbch\af31505\loch\f2 on details for all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webst\hich\af2\dbch\af31505\loch\f2 er"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroups -MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\XD7_Inventory_V2.ps1 -DeliveryGroups -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs and
 \par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micr\hich\af2\dbch\af31505\loch\f2 osoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page \hich\af2\dbch\af31505\loch\f2 format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------------\hich\af2\dbch\af31505\loch\f2 ------------ EXAMPLE 10 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Applications
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all applications.
-\par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\U\hich\af2\dbch\af31505\loch\f2 serInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Uses all Defau\hich\af2\dbch\af31505\loch\f2 lt values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1368,52 +1375,52 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -Policies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Policies.
+\par \hich\af2\dbch\af31505\loch\f2     Creates \hich\af2\dbch\af31505\loch\f2 a report with full details for Policies.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C\hich\af2\dbch\af31505\loch\f2 arl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory_V2.ps1 -NoPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl We\hich\af2\dbch\af31505\loch\f2 bster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD\hich\af2\dbch\af31505\loch\f2 7_Inventory_V2.ps1 -NoADPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory_V2.ps1 -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD-based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" o\hich\af2\dbch\af31505\loch\f2 r
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1433,7 +1440,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1452,7 +1459,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1474,7 +1481,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for \hich\af2\dbch\af31505\loch\f2 the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1498,7 +1505,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1516,7 +1523,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1534,7 +1541,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1561,7 +1568,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Car\hich\af2\dbch\af31505\loch\f2 l Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1585,7 +1592,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1599,7 +1606,8 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for \hich\af2\dbch\af31505\loch\f2 the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2         Controller named DDC01 for the AdminAddress.
 \par 
 \par 
@@ -1614,7 +1622,8 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
+\hich\af2\dbch\af31505\loch\f2  (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1630,7 +1639,8 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Dr. Watson for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
@@ -1647,7 +1657,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     Uses:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company \hich\af2\dbch\af31505\loch\f2 Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par 
 \par 
@@ -1665,12 +1675,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2022 at 6PM is 2022-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2022-06-01_1800.docx
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 The o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 \hich\af2\dbch\af31505\loch\f2 
+utput filename will be XD7SiteName_2022-06-01_1800.docx
 \par 
 \par 
 \par 
@@ -1687,12 +1698,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd\hich\af2\dbch\af31505\loch\f2 _HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2022 at 6PM is 2022-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2022-06-01_1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 \hich\af2\dbch\af31505\loch\f2  at 6PM is 2022-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 The o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 \hich\af2\dbch\af31505\loch\f2 
+utput filename will be XD7SiteName_2022-06-01_1800.pdf
 \par 
 \par 
 \par 
@@ -1709,7 +1721,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the\hich\af2\dbch\af31505\loch\f2  Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par 
 \par 
@@ -1726,9 +1738,10 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Car\hich\af2\dbch\af31505\loch\f2 l Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Output file is saved in the path \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 The o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 \hich\af2\dbch\af31505\loch\f2 
+utput file is saved in the path \\\\FileServer\\ShareName
 \par 
 \par 
 \par 
@@ -1745,7 +1758,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
 \par 
 \par 
@@ -1763,7 +1776,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page\hich\af2\dbch\af31505\loch\f2  format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with Delivery Group details.
 \par 
 \par 
@@ -1781,7 +1794,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Delivery Groups section of the report with no Delivery Group details.
 \par 
 \par 
@@ -1801,7 +1814,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2     Adds the information on over 300 Broker registry keys to the Controllers section.
 \par 
 \par 
@@ -1819,7 +1832,8 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 User\hich\af2\dbch\af31505\loch\f2 name}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12058823\charrsid12058823 .
 \par \hich\af2\dbch\af31505\loch\f2     Adds the information on VDA registry keys to Appendix A.
 \par \hich\af2\dbch\af31505\loch\f2     Forces the MachineCatalogs parameter to \hich\af2\dbch\af31505\loch\f2 $True
 \par 
@@ -1838,7 +1852,8 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
@@ -1875,7 +1890,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11078157 \hich\af2\dbch\af31505\loch\f2 Username}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 .
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Create\hich\af2\dbch\af31505\loch\f2 s a text file named XAXDV2InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
@@ -1939,12 +1954,12 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid276536 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid276536 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e42c}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003e42c3a}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid276536 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid276536 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030038}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030038ff}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the \hich\af2\dbch\af31505\loch\f2 "Less
@@ -1969,7 +1984,7 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
  HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid276536 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid12058823\charrsid276536 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-de\hich\af2\dbch\af31505\loch\f2 
 vice-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12058823\charrsid12058823 
 \par 
@@ -2139,10 +2154,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e50000000000000000000000004018
-9ad44f41d80103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff02000000000000000000000000000000000000000000000040189ad44f41d801
-40189ad44f41d80100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff03000000000000000000000000000000000000000000000040189ad44f41
-d80140189ad44f41d8010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e50000000000000000000000008072
+90941f99d80103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000807290941f99d801
+807290941f99d80100000000000000000000000054004300d500d60046004b004d00d1004b004500c600da00d500c2004b0047004c00d10041004d00c00041003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000807290941f99
+d801807290941f99d8010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/XD7_V2_Script_ChangeLog.txt
+++ b/XD7_V2_Script_ChangeLog.txt
@@ -3,6 +3,15 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
+#Version 2.49 16-Jul-2022
+#	Fixed bug reported by James Rankin where in Function OutputDatastores I didn't check for SQLServerName,TCPPortNumber
+#		https://support.citrix.com/article/CTX234610/how-to-configure-xendesktop-to-use-custom-sql-port
+#		For example, to to [sic] add custom port to the connection strings, then set the $ServerName variable to "DBServername\Instance,CustomPortNumber".
+#		Also fixed a bug where if unable to connect to the SQL server, that error was not handled and many variables were then not defined
+#	Updated Function GetDBCompatibilityLevel to support SQL Server 2022
+#	Updated the help text
+#	Updated the ReadMe file
+
 #Version 2.48 26-Apr-2022
 #	Fixed text output for hardware inventory
 #	General code cleanup


### PR DESCRIPTION
#Version 2.49 16-Jul-2022
#	Fixed bug reported by James Rankin where in Function OutputDatastores I didn't check for SQLServerName,TCPPortNumber
#		https://support.citrix.com/article/CTX234610/how-to-configure-xendesktop-to-use-custom-sql-port
#		For example, to to [sic] add custom port to the connection strings, then set the $ServerName variable to "DBServername\Instance,CustomPortNumber".
#		Also fixed a bug where if unable to connect to the SQL server, that error was not handled and many variables were then not defined
#	Updated Function GetDBCompatibilityLevel to support SQL Server 2022
#	Updated the help text
#	Updated the ReadMe file